### PR TITLE
Fix small typo: patforms -> platforms

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,7 +1,7 @@
 # Summary
 
 - [Upgrading topgrade](./upgrade.md)
-- [Supported patforms](./platforms.md)
+- [Supported platforms](./platforms.md)
 - [Windows](./windows/README.md)
   - [Step]()
 - [Linux]()


### PR DESCRIPTION
Fixing a small typo in the menu.

Thank you for keeping `topgrade` maintained! ❤️ 