### PR TITLE
Use upper-case naming (Topgrade) everywhere & some small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # [topgrade-rs.github.io](https://topgrade-rs.github.io)
 
-This is where the documentation of topgrade lives 
+This is where the documentation of Topgrade lives.

--- a/intro.md
+++ b/intro.md
@@ -1,3 +1,3 @@
 # Topgrade
 
-Keeping your system up to date usually involves invoking multiple package managers. This results in big, non-portable shell one-liners saved in your shell. To remedy this, Topgrade detects which tools you use and runs the appropriate commands to update them.
+Keeping your system up to date usually involves invoking multiple package managers. This results in big, non-portable shell one-liners saved in your shell. To remedy this, **Topgrade** detects which tools you use and runs the appropriate commands to update them.

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,8 +1,8 @@
 # Summary
 
-- [Get started](./intro.md)
-- [Upgrading topgrade](./upgrade.md)
-- [Supported platforms](./platforms.md)
+- [Get Started](./intro.md)
+- [Upgrading Topgrade](./upgrade.md)
+- [Supported Platforms](./platforms.md)
 - [Windows](./windows/README.md)
   - [Step]()
 - [Linux]()

--- a/src/windows/README.md
+++ b/src/windows/README.md
@@ -4,6 +4,6 @@ Windows is fully supported by Topgrade. You can either install it from Scoop or 
 
 One thing to note is that Topgrade will fail to upgrade any application used for launching it, such as 3rd party terminals like cmder.
 
-My personal recommendation is to create a shortcut for `topgrade --keep` and set this shortcut to always run as administrator, then invoke Topgrade by doubling clicking the shortcut. This will make sure Topgrade always runs with administrative privileges by Windows' built in terminal.
+We recommend to create a shortcut for `topgrade --keep` and set this shortcut to always run as administrator, then invoke Topgrade by doubling clicking the shortcut. This will make sure Topgrade always runs with administrative privileges by Windows' built in terminal.
 
 Note that Togprade will probably fail to upgrade itself if installed using `scoop`.

--- a/src/windows/README.md
+++ b/src/windows/README.md
@@ -4,6 +4,6 @@ Windows is fully supported by Topgrade. You can either install it from Scoop or 
 
 One thing to note is that Topgrade will fail to upgrade any application used for launching it, such as 3rd party terminals like cmder.
 
-My personal recommendation is to create a shortcut for `topgrade --keep` and set this shortcut to always run as administrator, then invoke Topgrade by doubling clicking the shortcut. This will make sure Topgrade always runs with administrative privileges by Windows' built in terminal
+My personal recommendation is to create a shortcut for `topgrade --keep` and set this shortcut to always run as administrator, then invoke Topgrade by doubling clicking the shortcut. This will make sure Topgrade always runs with administrative privileges by Windows' built in terminal.
 
-Note that Togprade will probably fail to upgrade itself if installed using `scoop`
+Note that Togprade will probably fail to upgrade itself if installed using `scoop`.


### PR DESCRIPTION
In https://github.com/topgrade-rs/topgrade/issues/85 we have decided to use upper-case naming for "Topgrade" project references.