### PR TITLE
fix: Fix typo in BSD installation

### DIFF
--- a/src/bsd/README.md
+++ b/src/bsd/README.md
@@ -1,6 +1,6 @@
 # DragonFly and Free BSD
 
-## Instalation
+## Installation
 
 Either use `cargo install` or the compiled binaries from the release page.
 The compiled binaries contain a self-upgrading feature.


### PR DESCRIPTION
`Instalation` -> `Installation`